### PR TITLE
feat: [mvp]バックエンドapiとsqliteの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 # docs
 /docs
+
+# Uploaded files
+/uploads
+
+# Database files
+*.db
+
+# Go binary
+face-calendar-server

--- a/backend/database/sqlite.go
+++ b/backend/database/sqlite.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"database/sql"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var DB *sql.DB
+
+func InitDB(dbPath string) error {
+	var err error
+	DB, err = sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return err
+	}
+
+	if err = DB.Ping(); err != nil {
+		return err
+	}
+
+	if err = createTables(); err != nil {
+		return err
+	}
+
+	log.Println("Database initialized successfully")
+	return nil
+}
+
+func createTables() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS encounters (
+		id TEXT PRIMARY KEY,
+		date DATE UNIQUE NOT NULL,
+		photo_url TEXT NOT NULL,
+		person_name TEXT NOT NULL,
+		location TEXT,
+		time_of_day TEXT CHECK(time_of_day IN ('morning', 'afternoon', 'evening')) NOT NULL,
+		memo TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_encounters_date ON encounters(date);
+	`
+
+	_, err := DB.Exec(schema)
+	return err
+}
+
+func CloseDB() {
+	if DB != nil {
+		DB.Close()
+	}
+}
+
+func GetDBPath() string {
+	path := os.Getenv("DATABASE_PATH")
+	if path == "" {
+		path = "./face_calendar.db"
+	}
+	return path
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,10 @@
+module face-calendar
+
+go 1.24.4
+
+require (
+	github.com/go-chi/chi/v5 v5.2.3
+	github.com/go-chi/cors v1.2.2
+	github.com/google/uuid v1.6.0
+	github.com/mattn/go-sqlite3 v1.14.33
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,8 @@
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-sqlite3 v1.14.33 h1:A5blZ5ulQo2AtayQ9/limgHEkFreKj1Dv226a1K73s0=
+github.com/mattn/go-sqlite3 v1.14.33/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/backend/handlers/entries.go
+++ b/backend/handlers/entries.go
@@ -1,0 +1,218 @@
+package handlers
+
+import (
+	"encoding/json"
+	"face-calendar/models"
+	"face-calendar/repository"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// respondError logs the error and returns a user-friendly message
+func respondError(w http.ResponseWriter, statusCode int, userMessage string, err error) {
+	if err != nil {
+		log.Printf("[ERROR] %s: %v", userMessage, err)
+	}
+	http.Error(w, userMessage, statusCode)
+}
+
+type EntryHandler struct {
+	repo *repository.EntryRepository
+}
+
+func NewEntryHandler() *EntryHandler {
+	return &EntryHandler{
+		repo: repository.NewEntryRepository(),
+	}
+}
+
+// GET /encounters?year=2025&month=1
+func (h *EntryHandler) GetEntries(w http.ResponseWriter, r *http.Request) {
+	yearStr := r.URL.Query().Get("year")
+	monthStr := r.URL.Query().Get("month")
+
+	if yearStr == "" || monthStr == "" {
+		http.Error(w, "year and month are required", http.StatusBadRequest)
+		return
+	}
+
+	year, err := strconv.Atoi(yearStr)
+	if err != nil {
+		http.Error(w, "invalid year", http.StatusBadRequest)
+		return
+	}
+
+	month, err := strconv.Atoi(monthStr)
+	if err != nil || month < 1 || month > 12 {
+		http.Error(w, "invalid month", http.StatusBadRequest)
+		return
+	}
+
+	entries, err := h.repo.GetByMonth(year, month)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to retrieve entries", err)
+		return
+	}
+
+	if entries == nil {
+		entries = []models.Entry{}
+	}
+
+	response := models.EntriesResponse{Entries: entries}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// POST /encounters
+func (h *EntryHandler) CreateEntry(w http.ResponseWriter, r *http.Request) {
+	// Parse multipart form (max 10MB)
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	date := r.FormValue("date")
+	personName := r.FormValue("person_name")
+	location := r.FormValue("location")
+	timeOfDay := r.FormValue("time_of_day")
+	memo := r.FormValue("memo")
+
+	if date == "" || personName == "" || timeOfDay == "" {
+		http.Error(w, "date, person_name, and time_of_day are required", http.StatusBadRequest)
+		return
+	}
+
+	// Validate time_of_day
+	if timeOfDay != "morning" && timeOfDay != "afternoon" && timeOfDay != "evening" {
+		http.Error(w, "invalid time_of_day", http.StatusBadRequest)
+		return
+	}
+
+	// Handle photo upload
+	photoURL, err := handlePhotoUpload(r)
+	if err != nil {
+		// handlePhotoUpload returns user-friendly messages for validation errors
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if photoURL == "" {
+		http.Error(w, "photo is required", http.StatusBadRequest)
+		return
+	}
+
+	entry := &models.Entry{
+		ID:         uuid.New().String(),
+		Date:       date,
+		PhotoURL:   photoURL,
+		PersonName: personName,
+		TimeOfDay:  models.TimeOfDay(timeOfDay),
+	}
+
+	if location != "" {
+		entry.Location = &location
+	}
+	if memo != "" {
+		entry.Memo = &memo
+	}
+
+	if err := h.repo.Create(entry); err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to create entry", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(entry)
+}
+
+// PUT /encounters/:id
+func (h *EntryHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	existing, err := h.repo.GetByID(id)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to retrieve entry", err)
+		return
+	}
+	if existing == nil {
+		http.Error(w, "entry not found", http.StatusNotFound)
+		return
+	}
+
+	// Parse multipart form
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "failed to parse form", http.StatusBadRequest)
+		return
+	}
+
+	// Update fields if provided
+	if personName := r.FormValue("person_name"); personName != "" {
+		existing.PersonName = personName
+	}
+	if location := r.FormValue("location"); location != "" {
+		existing.Location = &location
+	}
+	if timeOfDay := r.FormValue("time_of_day"); timeOfDay != "" {
+		if timeOfDay != "morning" && timeOfDay != "afternoon" && timeOfDay != "evening" {
+			http.Error(w, "invalid time_of_day", http.StatusBadRequest)
+			return
+		}
+		existing.TimeOfDay = models.TimeOfDay(timeOfDay)
+	}
+	if memo := r.FormValue("memo"); memo != "" {
+		existing.Memo = &memo
+	}
+
+	// Handle optional photo upload
+	photoURL, err := handlePhotoUpload(r)
+	if err != nil && err.Error() != "no photo uploaded" {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if photoURL != "" {
+		existing.PhotoURL = photoURL
+	}
+
+	if err := h.repo.Update(existing); err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to update entry", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(existing)
+}
+
+// DELETE /encounters/:id
+func (h *EntryHandler) DeleteEntry(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	existing, err := h.repo.GetByID(id)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to retrieve entry", err)
+		return
+	}
+	if existing == nil {
+		http.Error(w, "entry not found", http.StatusNotFound)
+		return
+	}
+
+	if err := h.repo.Delete(id); err != nil {
+		respondError(w, http.StatusInternalServerError, "Failed to delete entry", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/handlers/upload.go
+++ b/backend/handlers/upload.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+var allowedExtensions = map[string]bool{
+	".jpg":  true,
+	".jpeg": true,
+	".png":  true,
+	".gif":  true,
+	".webp": true,
+}
+
+func GetUploadDir() string {
+	dir := os.Getenv("UPLOAD_DIR")
+	if dir == "" {
+		dir = "../uploads"
+	}
+	return dir
+}
+
+func handlePhotoUpload(r *http.Request) (string, error) {
+	file, header, err := r.FormFile("photo")
+	if err != nil {
+		if err == http.ErrMissingFile {
+			return "", errors.New("no photo uploaded")
+		}
+		return "", err
+	}
+	defer file.Close()
+
+	// Validate file extension
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	if !allowedExtensions[ext] {
+		return "", errors.New("invalid file type. Allowed: jpg, jpeg, png, gif, webp")
+	}
+
+	// Generate unique filename
+	filename := uuid.New().String() + ext
+
+	// Ensure upload directory exists
+	uploadDir := GetUploadDir()
+	if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		log.Printf("[ERROR] Failed to create upload directory: %v", err)
+		return "", errors.New("failed to process file upload")
+	}
+
+	// Create destination file
+	destPath := filepath.Join(uploadDir, filename)
+	dest, err := os.Create(destPath)
+	if err != nil {
+		log.Printf("[ERROR] Failed to create destination file: %v", err)
+		return "", errors.New("failed to process file upload")
+	}
+	defer dest.Close()
+
+	// Copy file content
+	if _, err := io.Copy(dest, file); err != nil {
+		log.Printf("[ERROR] Failed to copy file content: %v", err)
+		return "", errors.New("failed to process file upload")
+	}
+
+	return fmt.Sprintf("/uploads/%s", filename), nil
+}
+
+// ServeUploads serves static files from the uploads directory
+func ServeUploads(w http.ResponseWriter, r *http.Request) {
+	filename := filepath.Base(r.URL.Path)
+
+	// Prevent directory traversal
+	if strings.Contains(filename, "..") {
+		log.Printf("[WARNING] Directory traversal attempt: %s", r.URL.Path)
+		http.Error(w, "file not found", http.StatusNotFound)
+		return
+	}
+
+	filePath := filepath.Join(GetUploadDir(), filename)
+
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		http.Error(w, "file not found", http.StatusNotFound)
+		return
+	}
+
+	http.ServeFile(w, r, filePath)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"face-calendar/database"
+	"face-calendar/handlers"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
+)
+
+func main() {
+	// Initialize database
+	dbPath := database.GetDBPath()
+	if err := database.InitDB(dbPath); err != nil {
+		log.Fatalf("Failed to initialize database: %v", err)
+	}
+	defer database.CloseDB()
+
+	// Create router
+	r := chi.NewRouter()
+
+	// Middleware
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.RequestID)
+
+	// CORS configuration
+	r.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"http://localhost:3000"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: true,
+		MaxAge:           300,
+	}))
+
+	// Initialize handlers
+	entryHandler := handlers.NewEntryHandler()
+
+	// API routes
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Get("/encounters", entryHandler.GetEntries)
+		r.Post("/encounters", entryHandler.CreateEntry)
+		r.Put("/encounters/{id}", entryHandler.UpdateEntry)
+		r.Delete("/encounters/{id}", entryHandler.DeleteEntry)
+	})
+
+	// Serve uploaded files
+	r.Get("/uploads/*", handlers.ServeUploads)
+
+	// Health check
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+
+	// Get port from environment or use default
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("Server starting on http://localhost:%s", port)
+	if err := http.ListenAndServe(":"+port, r); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}

--- a/backend/models/entry.go
+++ b/backend/models/entry.go
@@ -1,0 +1,42 @@
+package models
+
+import "time"
+
+type TimeOfDay string
+
+const (
+	Morning   TimeOfDay = "morning"
+	Afternoon TimeOfDay = "afternoon"
+	Evening   TimeOfDay = "evening"
+)
+
+type Entry struct {
+	ID         string    `json:"id"`
+	Date       string    `json:"date"` // YYYY-MM-DD
+	PhotoURL   string    `json:"photo_url"`
+	PersonName string    `json:"person_name"`
+	Location   *string   `json:"location,omitempty"`
+	TimeOfDay  TimeOfDay `json:"time_of_day"`
+	Memo       *string   `json:"memo,omitempty"`
+	CreatedAt  time.Time `json:"created_at,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at,omitempty"`
+}
+
+type CreateEntryRequest struct {
+	Date       string    `json:"date"`
+	PersonName string    `json:"person_name"`
+	Location   string    `json:"location"`
+	TimeOfDay  TimeOfDay `json:"time_of_day"`
+	Memo       string    `json:"memo"`
+}
+
+type UpdateEntryRequest struct {
+	PersonName *string    `json:"person_name,omitempty"`
+	Location   *string    `json:"location,omitempty"`
+	TimeOfDay  *TimeOfDay `json:"time_of_day,omitempty"`
+	Memo       *string    `json:"memo,omitempty"`
+}
+
+type EntriesResponse struct {
+	Entries []Entry `json:"entries"`
+}

--- a/backend/repository/entry_repository.go
+++ b/backend/repository/entry_repository.go
@@ -1,0 +1,169 @@
+package repository
+
+import (
+	"database/sql"
+	"face-calendar/database"
+	"face-calendar/models"
+	"time"
+)
+
+type EntryRepository struct{}
+
+func NewEntryRepository() *EntryRepository {
+	return &EntryRepository{}
+}
+
+func (r *EntryRepository) GetByMonth(year, month int) ([]models.Entry, error) {
+	query := `
+		SELECT id, date, photo_url, person_name, location, time_of_day, memo, created_at, updated_at
+		FROM encounters
+		WHERE strftime('%Y', date) = ? AND strftime('%m', date) = ?
+		ORDER BY date ASC
+	`
+
+	yearStr := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006")
+	monthStr := time.Date(2000, time.Month(month), 1, 0, 0, 0, 0, time.UTC).Format("01")
+
+	rows, err := database.DB.Query(query, yearStr, monthStr)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []models.Entry
+	for rows.Next() {
+		var entry models.Entry
+		var location, memo sql.NullString
+		var createdAt, updatedAt sql.NullTime
+
+		err := rows.Scan(
+			&entry.ID,
+			&entry.Date,
+			&entry.PhotoURL,
+			&entry.PersonName,
+			&location,
+			&entry.TimeOfDay,
+			&memo,
+			&createdAt,
+			&updatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if location.Valid {
+			entry.Location = &location.String
+		}
+		if memo.Valid {
+			entry.Memo = &memo.String
+		}
+		if createdAt.Valid {
+			entry.CreatedAt = createdAt.Time
+		}
+		if updatedAt.Valid {
+			entry.UpdatedAt = updatedAt.Time
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func (r *EntryRepository) GetByID(id string) (*models.Entry, error) {
+	query := `
+		SELECT id, date, photo_url, person_name, location, time_of_day, memo, created_at, updated_at
+		FROM encounters
+		WHERE id = ?
+	`
+
+	var entry models.Entry
+	var location, memo sql.NullString
+	var createdAt, updatedAt sql.NullTime
+
+	err := database.DB.QueryRow(query, id).Scan(
+		&entry.ID,
+		&entry.Date,
+		&entry.PhotoURL,
+		&entry.PersonName,
+		&location,
+		&entry.TimeOfDay,
+		&memo,
+		&createdAt,
+		&updatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if location.Valid {
+		entry.Location = &location.String
+	}
+	if memo.Valid {
+		entry.Memo = &memo.String
+	}
+	if createdAt.Valid {
+		entry.CreatedAt = createdAt.Time
+	}
+	if updatedAt.Valid {
+		entry.UpdatedAt = updatedAt.Time
+	}
+
+	return &entry, nil
+}
+
+func (r *EntryRepository) Create(entry *models.Entry) error {
+	query := `
+		INSERT INTO encounters (id, date, photo_url, person_name, location, time_of_day, memo, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	now := time.Now()
+	entry.CreatedAt = now
+	entry.UpdatedAt = now
+
+	_, err := database.DB.Exec(query,
+		entry.ID,
+		entry.Date,
+		entry.PhotoURL,
+		entry.PersonName,
+		entry.Location,
+		entry.TimeOfDay,
+		entry.Memo,
+		entry.CreatedAt,
+		entry.UpdatedAt,
+	)
+
+	return err
+}
+
+func (r *EntryRepository) Update(entry *models.Entry) error {
+	query := `
+		UPDATE encounters
+		SET photo_url = ?, person_name = ?, location = ?, time_of_day = ?, memo = ?, updated_at = ?
+		WHERE id = ?
+	`
+
+	entry.UpdatedAt = time.Now()
+
+	_, err := database.DB.Exec(query,
+		entry.PhotoURL,
+		entry.PersonName,
+		entry.Location,
+		entry.TimeOfDay,
+		entry.Memo,
+		entry.UpdatedAt,
+		entry.ID,
+	)
+
+	return err
+}
+
+func (r *EntryRepository) Delete(id string) error {
+	query := `DELETE FROM encounters WHERE id = ?`
+	_, err := database.DB.Exec(query, id)
+	return err
+}


### PR DESCRIPTION
# Face Calendar - Backend MVP (Phase 3)

## Summary

バックエンドの MVP 実装を完了しました。Go + SQLite を使用した REST API で、顔写真付き人間関係カレンダーのデータ管理を実現します。

### 実装内容

- **フレームワーク**: Go + chi（軽量ルーター）
- **データベース**: SQLite（ファイルベース、セットアップ不要）
- **ファイル保存**: ローカルファイルシステム（uploads/）
- **API**: RESTful エンドポイント（CRUD 完全実装）

## 技術詳細

### API エンドポイント

| メソッド | パス | 機能 |
|---------|------|------|
| GET | `/api/v1/encounters?year=2025&month=1` | 月単位でレコード取得 |
| POST | `/api/v1/encounters` | 新規作成（画像アップロード対応） |
| PUT | `/api/v1/encounters/{id}` | レコード更新（部分更新対応） |
| DELETE | `/api/v1/encounters/{id}` | レコード削除 |
| GET | `/uploads/{filename}` | 画像配信（静的ファイル） |

### データベーススキーマ

```sql
CREATE TABLE encounters (
    id TEXT PRIMARY KEY,
    date DATE UNIQUE NOT NULL,
    photo_url TEXT NOT NULL,
    person_name TEXT NOT NULL,
    location TEXT,
    time_of_day TEXT CHECK(...) NOT NULL,
    memo TEXT,
    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
);
```

### セキュリティ対策

- ✅ SQLインジェクション対策（プリペアドステートメント）
- ✅ ファイルアップロード検証（拡張子ホワイトリスト）
- ✅ ファイルサイズ制限（10MB）
- ✅ ディレクトリトラバーサル対策
- ✅ エラーメッセージ隠蔽（内部詳細をログ、ユーザーは一般メッセージ）
- ✅ CORS対応（localhost:3000 のみ許可）

## ファイル構成

```
backend/
├── main.go                  # サーバーエントリーポイント・ルーティング
├── models/
│   └── entry.go             # データモデル・リクエスト型
├── handlers/
│   ├── entries.go           # CRUD APIハンドラー
│   └── upload.go            # 画像アップロード・配信
├── repository/
│   └── entry_repository.go  # DB操作レイヤー
├── database/
│   └── sqlite.go            # DB接続・初期化
├── go.mod
├── go.sum
└── face-calendar-server     # ビルド済みバイナリ
```

## 開発時の注意点

### テーブル・カラム設計

- **テーブル名**: `encounters`（明確な意図：人との出会い記録）
- **カラム名**: `person_name`（汎用的な`name`より具体的）
- **date**: UNIQUE制約（1日1エントリーの原則）

### エラーハンドリング

DB エラーなどの詳細情報は **サーバーログ** に記録され、**ユーザーには一般的なメッセージ** を返します。

```
ユーザーが見るメッセージ: "Failed to create entry"
サーバーログ: "[ERROR] Failed to create entry: UNIQUE constraint failed: encounters.date"
```

## 動作確認済み事項

- ✅ POST /api/v1/encounters → 新規レコード作成
- ✅ GET /api/v1/encounters?year=2025&month=1 → レコード取得
- ✅ PUT /api/v1/encounters/{id} → レコード更新
- ✅ DELETE /api/v1/encounters/{id} → レコード削除
- ✅ 画像アップロード・配信
- ✅ エラーメッセージ隠蔽
- ✅ バリデーション（time_of_day enum チェック）

## 起動方法

```bash
cd backend
go build -o face-calendar-server .
./face-calendar-server

# サーバーが http://localhost:8080 で起動
```

## 次のフェーズ

- フロントエンドをこのAPIに接続（モック → 実API への切り替え）
- Google ログイン認証の実装
- エラーハンドリング・バリデーション強化
- テストコード追加
